### PR TITLE
Stop clipping long experience entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,9 +276,11 @@
         <h3 class="timeline-title">AI Engineer</h3>
         <div class="timeline-desc">Solvigo AB</div>
         <div class="exp-details">
-          I develop intelligent system solutions that solve real problems for our customers. My work spans the full chain, from identifying friction points and understanding the problems that slow people down, to designing, building, and shipping the technical AI solutions that fix them.
+          <div class="exp-details-inner">
+            I develop intelligent system solutions that solve real problems for our customers. My work spans the full chain, from identifying friction points and understanding the problems that slow people down, to designing, building, and shipping the technical AI solutions that fix them.
 
 I take ownership end to end: understanding the actual need, translating it into a technical approach, and delivering working software that makes it into people's hands. I care as much about the problem being worth solving as I do about the engineering behind the solution.
+          </div>
         </div>
       </div>
       <div class="timeline-item" data-reveal data-delay="100" tabindex="0" role="button" aria-expanded="false">
@@ -288,7 +290,9 @@ I take ownership end to end: understanding the actual need, translating it into 
         <h3 class="timeline-title">Master's Thesis Student</h3>
         <div class="timeline-desc">Softronic AB</div>
         <div class="exp-details">
-          Carried out my Master's thesis at Softronic AB, researching how historical operational data can be used to predict transport delays in courier logistics and identify the factors that most strongly influence service reliability, combining applied machine learning with real-world operations data.
+          <div class="exp-details-inner">
+            Carried out my Master's thesis at Softronic AB, researching how historical operational data can be used to predict transport delays in courier logistics and identify the factors that most strongly influence service reliability, combining applied machine learning with real-world operations data.
+          </div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -1203,18 +1203,27 @@ a {
   color: var(--accent);
 }
 
+/* Animating 0fr -> 1fr resolves to whatever the text actually measures, so
+   long entries can't be clipped the way a fixed max-height clipped them once
+   the copy rewrapped on a narrow screen. */
 .exp-details {
-  max-height: 0;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
   opacity: 0;
+  transition: grid-template-rows 0.4s cubic-bezier(.16,1,.3,1), opacity 0.3s ease, margin-top 0.4s ease;
+}
+
+.exp-details-inner {
+  /* min-height:0 lets the grid row shrink below the text's own height. */
+  min-height: 0;
+  overflow: hidden;
   font-size: 15px;
   line-height: 1.7;
   color: var(--muted-soft);
-  transition: max-height 0.4s cubic-bezier(.16,1,.3,1), opacity 0.3s ease, margin-top 0.4s ease;
 }
 
 .timeline-cards .timeline-item.open .exp-details {
-  max-height: 320px;
+  grid-template-rows: 1fr;
   opacity: 1;
   margin-top: 14px;
 }


### PR DESCRIPTION
## The bug

The Solvigo AB entry in Career & Experience cuts off mid-sentence on phones once expanded.

**Cause:** the expanded state of `.exp-details` animated to a hard-coded `max-height: 320px`.

```css
.timeline-cards .timeline-item.open .exp-details {
  max-height: 320px;   /* fits on a desktop, not once the copy rewraps */
}
```

That entry is ~530 characters. At `15px / 1.7` it comes to roughly 12 lines on a desktop card — under the cap — but around 16 lines on a phone, needing ~410px. Everything past 320px was clipped. The Softronic entry is short enough to have stayed under the cap, which is why only one of the two looked broken.

## The fix

Animate `grid-template-rows` from `0fr` to `1fr` against an inner wrapper, rather than animating toward a guessed pixel height:

```css
.exp-details {
  display: grid;
  grid-template-rows: 0fr;
  transition: grid-template-rows 0.4s cubic-bezier(.16,1,.3,1), …;
}
.exp-details-inner { min-height: 0; overflow: hidden; }
.timeline-cards .timeline-item.open .exp-details { grid-template-rows: 1fr; }
```

The open state now resolves to whatever the text actually measures, at any viewport width and any length of copy. No measurement in JS, no resize handler, and the same bug can't return when an entry is edited. The toggle JS is unchanged — it still just flips the `.open` class.

`min-height: 0` on the inner wrapper is what lets the grid row shrink below the text's intrinsic height; without it the collapsed state would not reach zero.

Browser support for animated `0fr → 1fr` is Chrome 107+, Firefox 66+, Safari 16+. Older browsers get an instant open/close instead of a transition, never a clip.

## Note, not fixed here

`.exp-details` has no `white-space` rule, so the blank line between the Solvigo entry's two paragraphs collapses and the text renders as one continuous block. That looks unintended given the source is written as two paragraphs, but it's a separate issue from the clipping and changes how the entry reads, so I left it alone.

## Verification

Static only — CSS brace balance, HTML nesting, `node --check`, and a grep confirming no other fixed `max-height` clips remain (the two that are left are the CLI log's intentional scroll bounds). Not opened in a browser.
